### PR TITLE
RNMT-2628 Allow developers to disable the injection of the viewport-fit meta tag for iOS 12 devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-statusbar",
-  "version": "2.4.2-dev",
+  "version": "2.4.2-OS2",
   "description": "Cordova StatusBar Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-statusbar"
-    version="2.4.2-OS1">
+    version="2.4.2-OS2">
     <name>StatusBar</name>
     <description>Cordova StatusBar Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -178,6 +178,17 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
     [self.commandDelegate sendPluginResult:result callbackId:_eventsCallbackId];
 }
 
+- (void)disableViewportFitForiOS12:(BOOL)disable {
+    if (_eventsCallbackId == nil) {
+        return;
+    }
+    
+    NSDictionary* payload = @{@"type": @"viewport", @"disableiOS12":@(disable)};
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:payload];
+    [result setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:result callbackId:_eventsCallbackId];
+}
+
 - (void) _ready:(CDVInvokedUrlCommand*)command
 {
     _eventsCallbackId = command.callbackId;
@@ -189,6 +200,10 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
             [self resizeWebView];
         }
     }
+    
+    BOOL disableViewportFit = [[self.commandDelegate.settings objectForKey:[@"DisableViewportFitForiOS12" lowercaseString]] boolValue];
+    [self disableViewportFitForiOS12:disableViewportFit];
+    
 }
 
 - (void) initializeStatusBarBackgroundView

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -47,6 +47,8 @@ var StatusBar = {
 
     isVisible: true,
 
+    disableViewportFitiOS12: false,
+
     overlaysWebView: function (doOverlay) {
         exec(checkIfStatusBarOverlaysWebview, null, "StatusBar", "overlaysWebView", [doOverlay]);
     },
@@ -162,7 +164,7 @@ var injectViewportMetaTag = function(){
         var version = navigator.appVersion.match(/OS (\d+)_(\d+)_?(\d+)?/);
 
         if(Array.isArray(version) && version.length > 1 && !isNaN(version[1])){
-            if(Number(version[1]) >= IOS_11_VERSION){
+            if(Number(version[1]) == IOS_11_VERSION || (Number(version[1]) > IOS_11_VERSION && !StatusBar.disableViewportFitiOS12)){
                 var viewportMetaElem = document.getElementsByTagName("meta").namedItem("viewport");
                 
                 if(viewportMetaElem && !viewportMetaElem.content.includes("viewport-fit")) {
@@ -186,6 +188,12 @@ channel.deviceready.subscribe(function () {
                 if (res.type == 'tap') {
                     cordova.fireWindowEvent('statusTap');
                 }
+                else{
+                    if (res.type == 'viewport'){
+                        StatusBar.disableViewportFitiOS12 = res.disableiOS12;
+                        injectViewportMetaTag();
+                    }
+                }
             } else {
                 StatusBar.isVisible = res;
             }
@@ -193,6 +201,5 @@ channel.deviceready.subscribe(function () {
     
   
     onVisibilityChange();
-    
-    injectViewportMetaTag();
+        
 });


### PR DESCRIPTION
Adding a feature that allows developers to disable the injection of the viewport-fit meta tag for iOS 12 devices through extensibility configuration using the following preference:

`<preference name="DisableViewportFitForiOS12" value="true"/>`

Issue: https://outsystemsrd.atlassian.net/browse/RNMT-2628