### PR TITLE
RNMT-2665 Support for Notch on Android P apps

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -69,6 +69,12 @@ public class StatusBar extends CordovaPlugin {
                 // by the Cordova.
                 Window window = cordova.getActivity().getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                
+                // Allows app to overlap cutout area from device when in landscape mode (same as iOS)
+                // More info: https://developer.android.com/reference/android/R.attr.html#windowLayoutInDisplayCutoutMode
+                if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    window.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+                }
 
                 // Added to override logic if plugin is installed in OutSystems Now app.
                 boolean isOutSystemsNow = preferences.getBoolean("IsOutSystemsNow", false);


### PR DESCRIPTION
Sets `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` flag as default option to allow the app's content to extend into the cutout area on the short edge of the display in both portrait and landscape mode. This is also the behavior presented in iOS applications

- More info about the  [Android flags used](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#layoutInDisplayCutoutMode)
- More info about the [rationale and future work](https://docs.google.com/presentation/d/1_tEU6ZOdyCIEGmmCabtUhDgwUpwEsNUHMzyreXlh74Y/edit#slide=id.p4)
- More info about how to [Handle Safe Area Insets, Notch & Display Cutout for iPhone X, iPad X and Android P](https://felgo.com/cross-platform-app-development/notch-developer-guide-ios-android)

**!! PLEASE IGNORE THE EXCESSIVE PADDING OF TOP BAR — UI TWEAKS ARE STILL REQUIRED !!**

**Before**
![Screenshot_1555512991](https://user-images.githubusercontent.com/6913932/56298322-dcf35a00-6129-11e9-977a-7ad949116265.png)

**After**
![Screenshot_1555513019](https://user-images.githubusercontent.com/6913932/56298340-e381d180-6129-11e9-88f2-a92fe50e27d2.png)

References: https://outsystemsrd.atlassian.net/browse/RNMT-2665