### PR TITLE
RNMT-3245 Ignore DisableViewportFitForiOS12 preference when running on WKWebView

### DIFF
--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -25,6 +25,7 @@
 
 #import "CDVStatusBar.h"
 #import <objc/runtime.h>
+#import <WebKit/WebKit.h>
 #import <Cordova/CDVViewController.h>
 
 static const void *kHideStatusBar = &kHideStatusBar;
@@ -183,7 +184,9 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         return;
     }
     
-    NSDictionary* payload = @{@"type": @"viewport", @"disableiOS12":@(disable)};
+    // https://github.com/apache/cordova-ios/issues/417 does not apply to WKWebView, therefore always return NO when running there
+    // This entire workaround to disable viewport fit injection is to be _removed_ once WKWebView is the _sole_ option
+    NSDictionary* payload = @{@"type": @"viewport", @"disableiOS12": [self.webView isKindOfClass: [WKWebView class]] ? @(NO) : @(disable)};
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:payload];
     [result setKeepCallbackAsBool:YES];
     [self.commandDelegate sendPluginResult:result callbackId:_eventsCallbackId];


### PR DESCRIPTION
## Description
This commit essentially ignores DisableViewportFitForiOS12 preference when running on WKWebView.

## Context
https://github.com/apache/cordova-ios/issues/417 does not apply to WKWebView,
therefore always return NO when running there. This entire workaround to
disable viewport fit injection is to be _removed_ once WKWebView is the
_sole_ option, **to avoid creating a breaking change and two versions of the plugin to manage.**

References https://outsystemsrd.atlassian.net/browse/RNMT-3245

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [X] Changes require an update to the documentation
	- [X] Documentation has been updated accordingly