### PR TITLE
RNMT-3816 Support for device orientation changes

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -21,6 +21,7 @@ package org.apache.cordova.statusbar;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.Rect;
@@ -43,6 +44,7 @@ import java.util.Arrays;
 
 public class StatusBar extends CordovaPlugin {
     private static final String TAG = "StatusBar";
+    private static final String CORDOVA_STATIC_CHANNEL = "StatusBarStaticChannel";
 
     private boolean doOverlay;
 
@@ -367,4 +369,13 @@ public class StatusBar extends CordovaPlugin {
             }
         }
     }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+        pluginResult.setKeepCallback(true);
+        webView.sendPluginResult(pluginResult, CORDOVA_STATIC_CHANNEL);
+    }
+
 }

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -31,6 +31,8 @@
 static const void *kHideStatusBar = &kHideStatusBar;
 static const void *kStatusBarStyle = &kStatusBarStyle;
 
+static NSString* const StatusBarStaticChannel = @"StatusBarStaticChannel";
+
 @interface CDVViewController (StatusBar)
 
 @property (nonatomic, retain) id sb_hideStatusBar;
@@ -108,6 +110,10 @@ static const void *kStatusBarStyle = &kStatusBarStyle;
         [weakSelf resizeStatusBarBackgroundView];
         [weakSelf resizeWebView];
     });
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [pluginResult setKeepCallbackAsBool:YES];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:StatusBarStaticChannel];
 }
 
 - (void)pluginInitialize

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -147,6 +147,7 @@ var addStatusBarDataElement = function(){
    
     var getStatusBarHeight = function (height){
         document.body.setAttribute("data-status-bar-height",height);
+        document.body.style.setProperty('--status-bar-height', height + "px");
     };
 
     exec(getStatusBarHeight, 

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -203,3 +203,12 @@ channel.deviceready.subscribe(function () {
     onVisibilityChange();
         
 });
+
+// Called by the native side when a configuration change
+cordova.callbacks["StatusBarStaticChannel"] = {
+    success: function() {
+        onVisibilityChange();
+    },
+    fail: function() {
+    }
+};


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
OutSystems UI is relying in a data attribute of the document body to retrieve the status bar height in order to adapt the applications layout to it. This pull request introduces the required changes to support the device orientation changes and update the status bar height according to it.
In future releases, OutSystems UI will start using the CSS variable instead of a data attribute. This will allow to quickly adapt to changes. Also, the data attribute will remain for backward compatibility purposes. 

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes https://outsystemsrd.atlassian.net/browse/RNMT-3816

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [X] Android
- [X] iOS
- [X] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly