### PR TITLE
MABS 7 ::: iOS 14 ::: Review build warnings in Core plugins

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,7 +64,7 @@
         </config-file>
 
         <header-file src="src/ios/CDVStatusBar.h" />
-        <source-file src="src/ios/CDVStatusBar.m" />
+        <source-file src="src/ios/CDVStatusBar.m" compiler-flags="-w" />
     </platform>
 
     <platform name="windows">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR removes some build warnings.

## Context
<!--- Why is this change required? What problem does it solve? -->
The previous PR for this issue was incorrectly branched out and afterwards merged to master when this is a repository that contains an outsystems branch (which is where our customisations lie). This PR contains the same changes but is applied to the correct base branch.

Previous PR: https://github.com/OutSystems/cordova-plugin-statusbar/pull/10

Additionally, we'll reset the master branch to a point prior to this change and force-push it. The previous PR will therefore stop having any validity.

<!--- Place the link to the issue here -->
https://outsystemsrd.atlassian.net/browse/RNMT-4440

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
