### PR TITLE
RNMT-5852 StatusBar Plugin ::: Logic that gets the main view is running too soon

### DIFF
--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -16,18 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  *
-*/
+ */
 package org.apache.cordova.statusbar;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.res.Configuration;
-import android.content.res.TypedArray;
 import android.graphics.Color;
-import android.graphics.Rect;
 import android.os.Build;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
@@ -60,18 +56,19 @@ public class StatusBar extends CordovaPlugin {
         LOG.v(TAG, "StatusBar: initialization");
         super.initialize(cordova, webView);
 
-        this.cordova.getActivity().runOnUiThread(new Runnable() {
+        Activity activity = cordova.getActivity();
+        ActivityAssistant.getInstance().assistActivity(activity);
+
+        activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 doOverlay = preferences.getBoolean("StatusBarOverlaysWebView", false);
-
-                ActivityAssistant.getInstance().assistActivity(cordova.getActivity());
 
                 // Clear flag FLAG_FORCE_NOT_FULLSCREEN which is set initially
                 // by the Cordova.
                 Window window = cordova.getActivity().getWindow();
                 window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                
+
                 // Allows app to overlap cutout area from device when in landscape mode (same as iOS)
                 // More info: https://developer.android.com/reference/android/R.attr.html#windowLayoutInDisplayCutoutMode
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -98,8 +95,8 @@ public class StatusBar extends CordovaPlugin {
                     // Read 'StatusBarBackgroundColor' from config.xml, default is #000000.
                     setStatusBarBackgroundColor(preferences.getString("StatusBarBackgroundColor", "#000000"));
 
- 					// Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
-                	setStatusBarStyle(preferences.getString("StatusBarStyle", "lightcontent"));
+                    // Read 'StatusBarStyle' from config.xml, default is 'lightcontent'.
+                    setStatusBarStyle(preferences.getString("StatusBarStyle", "lightcontent"));
                 }
             }
         });
@@ -346,13 +343,13 @@ public class StatusBar extends CordovaPlugin {
                 int uiOptions = decorView.getSystemUiVisibility();
 
                 String[] darkContentStyles = {
-                    "default",
+                        "default",
                 };
 
                 String[] lightContentStyles = {
-                    "lightcontent",
-                    "blacktranslucent",
-                    "blackopaque",
+                        "lightcontent",
+                        "blacktranslucent",
+                        "blackopaque",
                 };
 
                 if (Arrays.asList(darkContentStyles).contains(style.toLowerCase())) {


### PR DESCRIPTION
References https://outsystemsrd.atlassian.net/browse/RNMT-5852

This logic is being run simply on a `runOnUiThread` block when the plugin gets initialised. At this point there is no guarantee that the view hierarchy is ready, which can lead to a crash here: https://github.com/OutSystems/cordova-plugin-statusbar/blob/610f68ac2a7a648c3a490f57474c720ba6335284/src/android/ActivityAssistant.java#L31

The stack trace:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.ViewGroup$LayoutParams android.view.View.getLayoutParams()' on a null object reference at
    org.apache.cordova.statusbar.ActivityAssistant.assistActivity(ActivityAssistant.java:31)
    at org.apache.cordova.statusbar.StatusBar$1.run(StatusBar.java:68)
    at android.app.Activity.runOnUiThread(Activity.java:7258)
    at org.apache.cordova.statusbar.StatusBar.initialize(StatusBar.java:63)
    at org.apache.cordova.CordovaPlugin.privateInitialize(CordovaPlugin.java:57)
    at org.apache.cordova.PluginManager.getPlugin(PluginManager.java:185)
    at org.apache.cordova.PluginManager.startupPlugins(PluginManager.java:108)
    at org.apache.cordova.PluginManager.init(PluginManager.java:96)
    at org.apache.cordova.CordovaWebViewImpl.loadUrlIntoView(CordovaWebViewImpl.java:141)
    at org.apache.cordova.CordovaWebViewImpl.loadUrl(CordovaWebViewImpl.java:207)
    at com.outsystems.plugins.deeplinks.OSDeepLinks$1$1.run(OSDeepLinks.java:166)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:226)
    at android.os.Looper.loop(Looper.java:313)
    at android.app.ActivityThread.main(ActivityThread.java:8669)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

To ensure this runs properly, we should run the logic inside a `post` block for a view we know exists, such as the window decor view.