### PR TITLE
RNMT-5973 ::: Remove duplicate and incomplete code

### DIFF
--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -157,7 +157,6 @@ var checkIfStatusBarOverlaysWebview = function(overlaying){
     }
 }
 
-
 var addStatusBarDataElement = function(){
 
     var getStatusBarHeight = function (height){
@@ -170,9 +169,7 @@ var addStatusBarDataElement = function(){
          "StatusBar",
          "getStatusBarHeight",
         []);
-
 }
-
 
 var injectViewportMetaTag = function(){
 
@@ -191,22 +188,6 @@ var injectViewportMetaTag = function(){
     }
 
 }
-
-
-var addStatusBarDataElement = function(){
-
-    var getStatusBarHeight = function (height){
-        document.body.setAttribute("data-status-bar-height",height);
-    };
-
-    exec(getStatusBarHeight,
-         null,
-         "StatusBar",
-         "getStatusBarHeight",
-        []);
-
-}
-
 
 var injectViewportMetaTag = function(){
 


### PR DESCRIPTION
This PR removes the duplicate and incomplete function `addStatusBarDataElement` that is making the `status-bar-height` CSS property no longer available.

Closes https://outsystemsrd.atlassian.net/browse/RNMT-5973