### PR TITLE
fix: (android) text colour not applied on API > 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Preferences
 
         <preference name="StatusBarBackgroundColor" value="#000000" />
 
-- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: `default`, `lightcontent`. `blacktranslucent` and `blackopaque` are also available, but __deprecated__, will be removed in next major release, use `lightcontent` instead.
+- __StatusBarStyle__ (status bar style, defaults to lightcontent). Set the status bar style (e.g. text color). Available options: `default`, `lightcontent` and `darkcontent`. `blacktranslucent` and `blackopaque` are also available, but __deprecated__, will be removed in next major release, use `lightcontent` instead.
 
         <preference name="StatusBarStyle" value="lightcontent" />
 
@@ -118,6 +118,7 @@ Although in the global scope, it is not available until after the `deviceready` 
 - StatusBar.overlaysWebView
 - StatusBar.styleDefault
 - StatusBar.styleLightContent
+- StatusBar.styleDarkContent
 - StatusBar.styleBlackTranslucent
 - StatusBar.styleBlackOpaque
 - StatusBar.backgroundColorByName
@@ -164,6 +165,7 @@ StatusBar.styleDefault
 =================
 
 Use the default statusbar (dark text, for light backgrounds).
+For iOS - dark or light text depending on a device current theme.
 
     StatusBar.styleDefault();
 
@@ -181,6 +183,21 @@ StatusBar.styleLightContent
 Use the lightContent statusbar (light text, for dark backgrounds).
 
     StatusBar.styleLightContent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+- Android 6+
+- Windows
+
+StatusBar.styleDarkContent
+=================
+
+Use the darkContent statusbar (dark text, for light backgrounds).
+
+    StatusBar.styleDarkContent();
 
 
 Supported Platforms

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -266,6 +266,16 @@ public class StatusBar extends CordovaPlugin {
             return true;
         }
 
+        if ("styleDarkContent".equals(action)) {
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    setStatusBarStyle("darkcontent");
+                }
+            });
+            return true;
+        }
+
         if ("styleBlackTranslucent".equals(action)) {
             this.cordova.getActivity().runOnUiThread(new Runnable() {
                 @Override
@@ -352,7 +362,8 @@ public class StatusBar extends CordovaPlugin {
                 int uiOptions = decorView.getSystemUiVisibility();
 
                 String[] darkContentStyles = {
-                        "default",
+                    "default",
+                    "darkcontent"
                 };
 
                 String[] lightContentStyles = {
@@ -371,7 +382,7 @@ public class StatusBar extends CordovaPlugin {
                     return;
                 }
 
-                LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
+                LOG.e(TAG, "Invalid style, must be either 'default', 'lightcontent', 'darkcontent' or the deprecated 'blacktranslucent' and 'blackopaque'");
             }
         }
     }

--- a/src/android/StatusBar.java
+++ b/src/android/StatusBar.java
@@ -28,6 +28,8 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.core.view.WindowInsetsControllerCompat;
+
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CordovaInterface;
@@ -373,12 +375,24 @@ public class StatusBar extends CordovaPlugin {
                 };
 
                 if (Arrays.asList(darkContentStyles).contains(style.toLowerCase())) {
-                    decorView.setSystemUiVisibility(uiOptions | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O){
+                        decorView.setSystemUiVisibility(uiOptions | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    }
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+                    WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(cordova.getActivity().getWindow(), decorView);
+                    wic.setAppearanceLightStatusBars(true);
+                    }
                     return;
                 }
 
                 if (Arrays.asList(lightContentStyles).contains(style.toLowerCase())) {
-                    decorView.setSystemUiVisibility(uiOptions & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O){
+                        decorView.setSystemUiVisibility(uiOptions & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+                    }
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
+                        WindowInsetsControllerCompat wic = new WindowInsetsControllerCompat(cordova.getActivity().getWindow(), decorView);
+                        wic.setAppearanceLightStatusBars(false);
+                    }
                     return;
                 }
 

--- a/src/browser/StatusBarProxy.js
+++ b/src/browser/StatusBarProxy.js
@@ -33,11 +33,12 @@ function notSupported (win, fail) {
 
 module.exports = {
     isVisible: false,
-    styleBlackTranslucent: notSupported,
-    styleDefault: notSupported,
-    styleLightContent: notSupported,
-    styleBlackOpaque: notSupported,
-    overlaysWebView: notSupported,
+    styleBlackTranslucent:notSupported,
+    styleDefault:notSupported,
+    styleLightContent:notSupported,
+    styleDarkContent: notSupported,
+    styleBlackOpaque:notSupported,
+    overlaysWebView:notSupported,
     styleLightContect: notSupported,
     backgroundColorByName: notSupported,
     backgroundColorByHexString: notSupported,

--- a/src/ios/CDVStatusBar.h
+++ b/src/ios/CDVStatusBar.h
@@ -36,6 +36,7 @@
 
 - (void) styleDefault:(CDVInvokedUrlCommand*)command;
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command;
+- (void) styleDarkContent:(CDVInvokedUrlCommand*)command;
 - (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command;
 - (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CDVStatusBar.m
+++ b/src/ios/CDVStatusBar.m
@@ -316,6 +316,8 @@ static NSString* const StatusBarStaticChannel = @"StatusBarStaticChannel";
         [self styleDefault:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"lightcontent"]) {
         [self styleLightContent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"darkcontent"]) {
+        [self styleDarkContent:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"blacktranslucent"]) {
         [self styleBlackTranslucent:nil];
     } else if ([lcStatusBarStyle isEqualToString:@"blackopaque"]) {
@@ -325,17 +327,21 @@ static NSString* const StatusBarStaticChannel = @"StatusBarStaticChannel";
 
 - (void) styleDefault:(CDVInvokedUrlCommand*)command
 {
-    if (@available(iOS 13.0, *)) {
-        // TODO - Replace with UIStatusBarStyleDarkContent once Xcode 10 support is dropped
-        [self setStyleForStatusBar:3];
-    } else {
-        [self setStyleForStatusBar:UIStatusBarStyleDefault];
-    }
+    [self setStyleForStatusBar:UIStatusBarStyleDefault];
 }
 
 - (void) styleLightContent:(CDVInvokedUrlCommand*)command
 {
     [self setStyleForStatusBar:UIStatusBarStyleLightContent];
+}
+
+- (void) styleDarkContent:(CDVInvokedUrlCommand*)command
+{
+    if (@available(iOS 13.0, *)) {
+        [self setStyleForStatusBar:UIStatusBarStyleDarkContent];
+    } else {
+        [self styleDefault: command];
+    }
 }
 
 - (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command

--- a/src/windows/StatusBarProxy.js
+++ b/src/windows/StatusBarProxy.js
@@ -80,6 +80,13 @@ module.exports = {
         }
     },
 
+    styleDarkContent: function () {
+        // dark text ( to be used on a light background )
+        if (isSupported()) {
+            getViewStatusBar().foregroundColor = { a: 0, r: 0, g: 0, b: 0 };
+        }
+    },
+
     styleBlackTranslucent: function () {
         // #88000000 ? Apple says to use lightContent instead
         return module.exports.styleLightContent();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -53,6 +53,9 @@ exports.defineAutoTests = function () {
             expect(window.StatusBar.styleLightContent).toBeDefined();
             expect(typeof window.StatusBar.styleLightContent).toBe('function');
 
+            expect(window.StatusBar.styleDarkContent).toBeDefined();
+            expect(typeof window.StatusBar.styleDarkContent).toBe("function");
+
             expect(window.StatusBar.styleBlackOpaque).toBeDefined();
             expect(typeof window.StatusBar.styleBlackOpaque).toBe('function');
 
@@ -95,6 +98,11 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         StatusBar.styleDefault();
     }
 
+    function doColor4() {
+        log('set style=darkcontent');
+        StatusBar.styleDarkContent();
+    }
+
     var showOverlay = true;
     function doOverlay () {
         showOverlay = !showOverlay;
@@ -114,6 +122,8 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         '</p> <div id="action-color2"></div>' +
         'Expected result: Status bar text will be a light (white) color' +
         '</p> <div id="action-color3"></div>' +
+        'Expected result: Status bar text will be a dark (black) color<br>for iOS - a device theme depending (black or white) color' +
+        '</p> <div id="action-color4"></div>' +
         'Expected result: Status bar text will be a dark (black) color' +
         '</p> <div id="action-overlays"></div>' +
         'Expected result:<br>Overlay true = status bar will lay on top of web view content<br>Overlay false = status bar will be separate from web view and will not cover content' +
@@ -170,10 +180,18 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     );
 
     createActionButton(
+        'Style=dark',
+        function () {
+            doColor4();
+        }, 
+        'action-color4'
+    );
+
+    createActionButton(
         'Toggle Overlays',
         function () {
             doOverlay();
-        },
+        }, 
         'action-overlays'
     );
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ interface StatusBar {
 
     /**
     * Use the default statusbar (dark text, for light backgrounds).
+    * For iOS - dark or light text depending on a device configuration.
     */
     styleDefault(): void;
 
@@ -33,6 +34,11 @@ interface StatusBar {
     * Use the lightContent statusbar (light text, for dark backgrounds).
     */
     styleLightContent(): void;
+
+    /**
+     * Use the darkContent statusbar (dark text, for light backgrounds).
+     */
+    styleDarkContent(): void;
 
     /**
     * Use the blackTranslucent statusbar (light text, for dark backgrounds).

--- a/www/statusbar.js
+++ b/www/statusbar.js
@@ -53,13 +53,18 @@ var StatusBar = {
     },
 
     styleDefault: function () {
-        // dark text ( to be used on a light background )
-        exec(null, null, 'StatusBar', 'styleDefault', []);
+        // dark text ( to be used on a light background and on iOS depending on a device configuration )
+        exec(null, null, "StatusBar", "styleDefault", []);
     },
 
     styleLightContent: function () {
         // light text ( to be used on a dark background )
         exec(null, null, 'StatusBar', 'styleLightContent', []);
+    },
+
+    styleDarkContent: function () {
+        // dark text ( to be used on a light background )
+        exec(null, null, "StatusBar", "styleDarkContent", []);
     },
 
     styleBlackTranslucent: function () {


### PR DESCRIPTION
<!--
setSystemUiVisibility is deprecated from API 26 and ineffective from API 30.

Updated the plugin to use setSystemUiVisibility for less than API 26 and to use the new WindowInsetsControllerCompat for API 26 and greater.

Tested and now works as expected on Android 13 devices.
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
